### PR TITLE
Switch to a more secure method for generating random file names.

### DIFF
--- a/src/dae/daeUtils.cpp
+++ b/src/dae/daeUtils.cpp
@@ -19,6 +19,8 @@
 
 #ifndef NO_BOOST
 #include <boost/filesystem.hpp> // THIS WAS NOT COMMENTED.
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
 #endif
 
 #include <cstdio> // for tmpnam
@@ -169,8 +171,13 @@ static string tmpDir = string(getenv("TMPDIR"));
 string cdom::getRandomFileName() {
     std::string randomSegment;
     // have to createa a buffer in order to make it multi-thread safe
+#ifdef NO_BOOST
     std::string tmpbuffer; tmpbuffer.resize(L_tmpnam*2+1);
     std::string tmp(tmpnam(&tmpbuffer[0]));
+#else
+    boost::uuids::uuid uuid = boost::uuids::random_generator()();
+    std::string tmp(boost::uuids::to_string(uuid));
+#endif
 #ifdef WIN32
     randomSegment = tmp.substr(tmp.find_last_of('\\')+1);
 #elif defined(__linux__) || defined(__linux)


### PR DESCRIPTION
Using tmpnam may generate strings that overlap with other files in some cases.

Therefore, it is now dangerous.

~~~
/usr/bin/ld: /home/runner/work/viewer/viewer/build-linux-x86_64/packages/lib/release/libcollada14dom.a(daeUtils.o): in function `cdom::getRandomFileName[abi:cxx11]()':
/home/runner/work/3p-colladadom/3p-colladadom/src/dae/daeUtils.cpp:173:(.text+0xcee): warning: the use of `tmpnam' is dangerous, better use `mkstemp'
~~~

We will replace it with a more secure function.